### PR TITLE
Fixed inertia and collision

### DIFF
--- a/src/cart_pole/cart_pole_bringup/urdf/cart_pole.urdf.xacro
+++ b/src/cart_pole/cart_pole_bringup/urdf/cart_pole.urdf.xacro
@@ -11,12 +11,12 @@
       </geometry>
     </visual>
     <collision>
-      <origin xyz="0 0 0" />
+      <origin xyz="0 0 1" />
       <geometry>
         <box size="10 0.05 0.05" />
       </geometry>
     </collision>
-    <xacro:box_inertia m="1" w="10" h="0.05" d="0.05" />
+    <xacro:box_inertia m="1" w="10" h="0.05" d="0.05"  xyz="0 0 1" />
   </link>
 
   <link name="cart">
@@ -32,7 +32,7 @@
         <box size="0.5 0.5 0.2" />
       </geometry>
     </collision>
-    <xacro:box_inertia m="0.4" w="0.5" h="0.2" d="0.5" />
+    <xacro:box_inertia m="0.4" w="0.5" h="0.5" d="0.2" />
   </link>
 
   <link name="pole_holder">
@@ -48,7 +48,7 @@
         <cylinder radius="0.05" length="0.05" />
       </geometry>
     </collision>
-    <xacro:cylinder_inertia m="0.001" r="0.05" h="0.05" />
+    <xacro:cylinder_inertia m="0.001" r="0.05" h="0.05" rpy="1.57 0 0" />
   </link>
 
   <joint name="pole_holder_base_to_pole_holder" type="revolute">

--- a/src/cart_pole/cart_pole_bringup/urdf/macros.urdf.xacro
+++ b/src/cart_pole/cart_pole_bringup/urdf/macros.urdf.xacro
@@ -1,16 +1,16 @@
 <?xml version="1.0"?>
 <robot name="cart_pole" xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="box_inertia" params="m w h d">
+  <xacro:macro name="box_inertia" params="m w h d xyz:='0.0 0.0 0.0' rpy:='0.0 0.0 0.0'">
     <inertial>
-      <origin xyz="0 0 0" rpy="${pi/2} 0 ${pi/2}"/>
+      <origin xyz="${xyz}" rpy="${rpy}"/>
       <mass value="${m}"/>
       <inertia ixx="${(m/12) * (h*h + d*d)}" ixy="0.0" ixz="0.0" iyy="${(m/12) * (w*w + d*d)}" iyz="0.0" izz="${(m/12) * (w*w + h*h)}"/>
     </inertial>
   </xacro:macro>
 
-  <xacro:macro name="cylinder_inertia" params="m r h">
+  <xacro:macro name="cylinder_inertia" params="m r h xyz:='0.0 0.0 0.0' rpy:='0.0 0.0 0.0'">
     <inertial>
-      <origin xyz="0 0 0" rpy="${pi/2} 0 0" />
+      <origin xyz="${xyz}" rpy="${rpy}"/>
       <mass value="${m}"/>
       <inertia ixx="${(m/12) * (3*r*r + h*h)}" ixy = "0" ixz = "0" iyy="${(m/12) * (3*r*r + h*h)}" iyz = "0" izz="${(m/2) * (r*r)}"/>
     </inertial>


### PR DESCRIPTION
Collisions before:
![image](https://github.com/user-attachments/assets/9d86240e-207e-4224-a29d-778d7a1e9ff9)


Inertia before:
![image](https://github.com/user-attachments/assets/ffff1d11-2a24-4562-9aa1-517e1fd2661f)


Collisions After fix:
![image](https://github.com/user-attachments/assets/4bca0b7a-2de1-4d4c-99a9-b910b62d06ef)


Inertia after fix:
![image](https://github.com/user-attachments/assets/efe4b3fa-8e3a-4adf-9483-317cfe0b477f)


The inertia of fixed the pole and the pole holder is not the same visualized as 3D model because they have different density of the material.